### PR TITLE
Add support for multiple mac monitors

### DIFF
--- a/public/js/ipc-handlers.js
+++ b/public/js/ipc-handlers.js
@@ -10,13 +10,17 @@ module.exports = {
 
         ipcMain.on('saveRegion', () => {
             const bounds = windows.getRegionSelectionWindow().getBounds();
-            stream.setStreamScreen(
-                screen.getDisplayNearestPoint(
-                    windows.getRegionSelectionWindow().getBounds()
-                )
-            );
+            
+            const streamScreen = screen.getDisplayNearestPoint(
+                windows.getRegionSelectionWindow().getBounds()
+            )
+            stream.setStreamScreen(streamScreen);
 
-            let streamRegion = { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height };
+            // Limit capture window to screen size
+            const width = Math.min(bounds.width, streamScreen.workAreaSize.width)
+            const height = Math.min(bounds.height, streamScreen.workAreaSize.width)
+
+            let streamRegion = { x: bounds.x, y: bounds.y, width: width, height: height };
             if (process.platform === "darwin") {
                 streamRegion.x -= stream.getStreamScreen().bounds.x;
                 streamRegion.y -= stream.getStreamScreen().bounds.y;


### PR DESCRIPTION
Adding support for multiple monitors on mac. The way the ffmpeg index was being calculated was causing the incorrect screen to be shared in the window. This uses a built-in mac util to figure out what the index should be.